### PR TITLE
Add vscode protocol redirect

### DIFF
--- a/api/runme.js
+++ b/api/runme.js
@@ -1,0 +1,5 @@
+export default function handler(req, res) {
+    const { repository, file } = req.query
+    if (!repository) return res.status(500).send('Expecting a repository to open')
+    res.redirect(308, `vscode://stateful.runme?command=setup&repository=${decodeURIComponent(repository)}&fileToOpen=${file || 'README.md'}`)
+  }


### PR DESCRIPTION
Usage example:

https://runme-dev-git-protocol-redirect-stateful.vercel.app/api/runme?repository=git@github.com:degrammer/runme-getting-started.git&fileToOpen=README.md

**fileToOpen** is optional, it will use by default README.md