### PR TITLE
Remove duplicate content

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -35,6 +35,8 @@ If you have Go developer tools installed, you can install it with go install:
 $ go install github.com/stateful/runme@latest
 ```
 
+If you don't have go developer tools installed and still want to use this method, [download and install go](https://go.dev/doc/install).
+
 ### All other platforms
 
 You can find a binary for your OS/arch on our [releases page](https://github.com/stateful/runme/releases). Let us know on [Discord](https://discord.com/invite/BQm8zRCBUY) if you have a preferred distribution mechanism.

--- a/docs/install.md
+++ b/docs/install.md
@@ -3,12 +3,6 @@ sidebar_position: 2
 title: Install Extension
 ---
 
-# Install Runme
-
-While VS Code extension and CLI can be used separately, consider installing both to get the most out of GUI and TUI experiences, respectively.
-
-## The VS Code Extension
-
 Open the `Extensions Tab` in the VS Code sidebar and search for **"Runme"**.
 
 ![install runme gif](../static/img/install.gif)
@@ -16,26 +10,6 @@ Open the `Extensions Tab` in the VS Code sidebar and search for **"Runme"**.
 Alternatively, you can go to the [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=stateful.runme) and click the green `Install` button.
 
 That's it. Now, any time you open a Markdown file (`*.md` or `*.mdx`) it will open as a Runme notebook.
-
-## The Command Line Interface
-
-On macOS you can install Runme via Homebrew.sh which receives regular updates:
-
-```sh
-    $ brew install stateful/tap/runme
-```
-
-If you don’t have homebrew, you can download it from [here](https://github.com/degrammer/runme-getting-started/blob/main/img/https:/brew.sh). Follow all the instructions and ensure brew is added to your PATH.
-
-Alternatively, check out [runme's releases](https://github.com/stateful/runme/releases) and select a binary for your OS/arch. Let us know [on Discord](https://discord.gg/stateful) if you have a preferred distribution mechanism.
-
-With Go dev tools installed, you can install `Runme` with `go install`:
-
-```sh
-$ go install github.com/stateful/runme@latest
-```
-
-If you don't have go developer tools installed and still want to use this method, [download and install go](https://go.dev/doc/install).
 
 ## Pre-release: Test drive new features early
 


### PR DESCRIPTION
On the `Install Extension` site we had docs around installing the CLI while we have that instruction almost 1:1 on a different page. This PR removes this duplication.

I could add a link on the `Install Extension` page saying: _"You like to install Runme as CLI? Go to '[CLI in the Terminal](https://runme.dev/docs/cli)'`.