### PR TITLE
Fix link color in dark mode

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -482,3 +482,6 @@ ol {
 .markdown a {
   color: var(--ifm-color-content-secondary);
 }
+html[data-theme="dark"] .markdown a {
+  color: var(--ifm-color-primary);
+}


### PR DESCRIPTION
Before:
<img width="1401" alt="Screenshot 2023-03-09 at 17 57 55" src="https://user-images.githubusercontent.com/731337/224203841-cbf3e853-989c-493d-a025-0c494443853d.png">

After:
<img width="1401" alt="Screenshot 2023-03-09 at 17 58 02" src="https://user-images.githubusercontent.com/731337/224203861-d7a3d9ee-7b20-4a06-a361-45d7967ad2bf.png">
