### PR TITLE
Fix sending undefined as string when missing query fileToOpen

### DIFF
--- a/api/runme.js
+++ b/api/runme.js
@@ -1,5 +1,5 @@
 export default function handler(req, res) {
-    const { repository, fileToOpen } = req.query
+    const { repository, fileToOpen = 'README.md' } = req.query
     if (!repository) return res.status(500).send('Expecting a repository to open')
-    res.redirect(308, `vscode://stateful.runme?command=setup&repository=${decodeURIComponent(repository)}&fileToOpen=${decodeURIComponent(fileToOpen) || 'README.md'}`)
+    res.redirect(308, `vscode://stateful.runme?command=setup&repository=${decodeURIComponent(repository)}&fileToOpen=${decodeURIComponent(fileToOpen)}`)
   }


### PR DESCRIPTION
Found a bug while testing. When the fileToOpen is missing, it sends "undefined" as String.