### PR TITLE
Attempt to make pipeline wait for Vercel job

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+- package-ecosystem: npm
+  directory: "/"
+  schedule:
+    interval: weekly
+    time: "11:00"
+  open-pull-requests-limit: 10
+  versioning-strategy: increase-if-necessary
+  ignore:
+    # we want to update this package manually as it changes
+    # the minimum required VS Code version for this extension
+    # to run
+    - dependency-name: "@mdx-js/react"

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -31,7 +31,8 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          wait-interval: 30 # seconds
+          check-name: 'Vercel'
+          wait-interval: 120 # seconds
           running-workflow-name: dependencies # wait for all checks except this one
           allowed-conclusions: success # all other checks must pass, being skipped or cancelled is not sufficient
 


### PR DESCRIPTION
Fixes #128

Not sure if this will fix the issue given that our Vercel integration is not really through a workflow but through web hooks. I'ld suggest we try this change and if it fails on us again, we can attempt this Github action: [`wait-for-vercel-preview`](https://github.com/patrickedqvist/wait-for-vercel-preview) or remove auto-updates entirely.

cc @sourishkrout 